### PR TITLE
support & require hsl-experimental 4.50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
+*.hhast.parser-cache
 *.swp
 *~

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Hack code.
 
 ## Requirements
 
-HHVM 3.29 and above.
+HHVM 4.41 and above.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
         "hhvm/hhast": "^4.0"
     },
     "require": {
-        "hhvm/hsl-experimental": "^4.0"
+        "hhvm/hsl-experimental": "^4.50"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af279b15850d47fead5dfe6e52f5ede1",
+    "content-hash": "1e6c36160466289f9bc7f31fe8d1bbf7",
     "packages": [
         {
             "name": "hhvm/hsl",
-            "version": "v4.0.0",
+            "version": "v4.40.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl.git",
-                "reference": "862e91698a121f6d57786dafa7ccdbfdd50ea3c2"
+                "reference": "b14a430062ad95c378765899f955457f3454f2f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl/zipball/862e91698a121f6d57786dafa7ccdbfdd50ea3c2",
-                "reference": "862e91698a121f6d57786dafa7ccdbfdd50ea3c2",
+                "url": "https://api.github.com/repos/hhvm/hsl/zipball/b14a430062ad95c378765899f955457f3454f2f9",
+                "reference": "b14a430062ad95c378765899f955457f3454f2f9",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.0"
+                "hhvm": "^4.25"
             },
             "require-dev": {
-                "facebook/fbexpect": "^2.0.0",
-                "hhvm/hacktest": "^1.0",
-                "hhvm/hhvm-autoload": "^2.0"
+                "facebook/fbexpect": "^2.5.1",
+                "hhvm/hacktest": "^1.0|^2.0",
+                "hhvm/hhvm-autoload": "^2.0",
+                "hhvm/hsl-experimental": "dev-master"
             },
             "type": "library",
             "extra": {
@@ -39,56 +40,62 @@
                 "MIT"
             ],
             "description": "The Hack Standard Library",
-            "time": "2019-02-08T21:25:25+00:00"
+            "time": "2020-01-08T23:12:08+00:00"
         },
         {
             "name": "hhvm/hsl-experimental",
-            "version": "v4.0.0",
+            "version": "v4.50.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl-experimental.git",
-                "reference": "208fa5defedb0deb99095eaa09a5255bae26a198"
+                "reference": "cf23c87c2b16cbffe067974b45beb5b512edd4eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl-experimental/zipball/208fa5defedb0deb99095eaa09a5255bae26a198",
-                "reference": "208fa5defedb0deb99095eaa09a5255bae26a198",
+                "url": "https://api.github.com/repos/hhvm/hsl-experimental/zipball/cf23c87c2b16cbffe067974b45beb5b512edd4eb",
+                "reference": "cf23c87c2b16cbffe067974b45beb5b512edd4eb",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.0",
-                "hhvm/hsl": "^4.0"
+                "hhvm": "^4.41",
+                "hhvm/hsl": "^4.15"
             },
             "require-dev": {
-                "facebook/fbexpect": "^2.0",
-                "hhvm/hacktest": "^1.0",
-                "hhvm/hhvm-autoload": "^2.0"
+                "facebook/fbexpect": "^2.7.0",
+                "hhvm/hacktest": "^2.0",
+                "hhvm/hhvm-autoload": "^2.0|^3.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "The Hack Standard Library - Experimental Additions",
-            "time": "2019-02-08T23:24:49+00:00"
+            "time": "2020-03-27T15:38:24+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "facebook/difflib",
-            "version": "v1.1",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/difflib.git",
-                "reference": "195502ecd77a691e91449a3b726c9c670a99addf"
+                "reference": "b697c0ac436629c8cd9627ab31a60777431f72f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/difflib/zipball/195502ecd77a691e91449a3b726c9c670a99addf",
-                "reference": "195502ecd77a691e91449a3b726c9c670a99addf",
+                "url": "https://api.github.com/repos/hhvm/difflib/zipball/b697c0ac436629c8cd9627ab31a60777431f72f6",
+                "reference": "b697c0ac436629c8cd9627ab31a60777431f72f6",
                 "shasum": ""
             },
             "require": {
+                "hhvm": "^4.8",
                 "hhvm/hsl": "^4.0"
             },
             "require-dev": {
@@ -107,31 +114,32 @@
             "license": [
                 "MIT"
             ],
-            "time": "2019-02-09T01:44:39+00:00"
+            "time": "2019-07-22T20:15:27+00:00"
         },
         {
             "name": "facebook/hh-clilib",
-            "version": "v2.1.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hh-clilib.git",
-                "reference": "44f30c1f07b9d36430bfff721a119a0d43b15edd"
+                "reference": "10845e8780436728cdc0b9abbe20446777bdb199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/44f30c1f07b9d36430bfff721a119a0d43b15edd",
-                "reference": "44f30c1f07b9d36430bfff721a119a0d43b15edd",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/10845e8780436728cdc0b9abbe20446777bdb199",
+                "reference": "10845e8780436728cdc0b9abbe20446777bdb199",
                 "shasum": ""
             },
             "require": {
+                "hhvm": "^4.41",
                 "hhvm/hsl": "^4.0",
-                "hhvm/hsl-experimental": "^4.0",
+                "hhvm/hsl-experimental": "^4.50",
                 "hhvm/type-assert": "^3.2"
             },
             "require-dev": {
-                "facebook/fbexpect": "^2.1.0",
-                "hhvm/hacktest": "^1.0.0",
-                "hhvm/hhast": "^4.0"
+                "facebook/fbexpect": "^2.6.1",
+                "hhvm/hacktest": "^2.0",
+                "hhvm/hhast": "^4.0.2"
             },
             "type": "library",
             "extra": {
@@ -143,39 +151,43 @@
             "license": [
                 "MIT"
             ],
-            "time": "2019-02-12T20:14:07+00:00"
+            "time": "2020-03-27T16:47:22+00:00"
         },
         {
             "name": "hhvm/hhast",
-            "version": "v4.0.3",
+            "version": "v4.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "38c7891725daae34ac4175deb410fc7be1caac3d"
+                "reference": "7fed6336ee9e59dbb6c835ee5bdd72d9ff2cfb02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/38c7891725daae34ac4175deb410fc7be1caac3d",
-                "reference": "38c7891725daae34ac4175deb410fc7be1caac3d",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/7fed6336ee9e59dbb6c835ee5bdd72d9ff2cfb02",
+                "reference": "7fed6336ee9e59dbb6c835ee5bdd72d9ff2cfb02",
                 "shasum": ""
             },
             "require": {
                 "facebook/difflib": "^1.0.0",
                 "facebook/hh-clilib": "^2.0.0",
-                "hhvm": "^4.0",
-                "hhvm/hhvm-autoload": "^2.0",
-                "hhvm/hsl": "^4.0",
-                "hhvm/type-assert": "^3.1"
+                "hhvm": "^4.41",
+                "hhvm/hhvm-autoload": "^2.0.4|^3.0",
+                "hhvm/hsl": "^4.25",
+                "hhvm/hsl-experimental": "^4.50",
+                "hhvm/type-assert": "^3.4"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.1.1",
                 "facebook/hack-codegen": "^4.0",
-                "hhvm/hacktest": "^1.3"
+                "hhvm/hacktest": "^2.0"
             },
             "bin": [
                 "bin/hhast-lint",
+                "bin/hhast-lint.hack",
                 "bin/hhast-inspect",
-                "bin/hhast-migrate"
+                "bin/hhast-inspect.hack",
+                "bin/hhast-migrate",
+                "bin/hhast-migrate.hack"
             ],
             "type": "library",
             "extra": {
@@ -187,25 +199,26 @@
             "license": [
                 "MIT"
             ],
-            "time": "2019-02-19T22:32:56+00:00"
+            "description": "A mutable AST library for Hack with linting and code migrations",
+            "time": "2020-03-27T17:22:11+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",
-            "version": "v2.0.3",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhvm-autoload.git",
-                "reference": "46b5f6759965a894f06e2cd1fc501f7783ee6830"
+                "reference": "645a83cb9a0ba97084a753a20bebfe4e9442f75c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/46b5f6759965a894f06e2cd1fc501f7783ee6830",
-                "reference": "46b5f6759965a894f06e2cd1fc501f7783ee6830",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/645a83cb9a0ba97084a753a20bebfe4e9442f75c",
+                "reference": "645a83cb9a0ba97084a753a20bebfe4e9442f75c",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
-                "hhvm": "^4.0",
+                "hhvm": "^4.25",
                 "hhvm/hsl": "^4.0"
             },
             "replace": {
@@ -213,7 +226,7 @@
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.1",
-                "hhvm/hacktest": "^1.0"
+                "hhvm/hacktest": "^2.0"
             },
             "bin": [
                 "bin/hh-autoload",
@@ -230,33 +243,33 @@
             },
             "autoload": {
                 "classmap": [
-                    "src/ComposerPlugin.php"
+                    "ComposerPlugin.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2019-02-13T17:18:00+00:00"
+            "time": "2020-02-07T21:25:25+00:00"
         },
         {
             "name": "hhvm/type-assert",
-            "version": "v3.3.1",
+            "version": "v3.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/type-assert.git",
-                "reference": "f207250e2f9d4602b28c25c8a83a34bc42811243"
+                "reference": "e076c42ed718929dbea96c0b354ebe96cccc2335"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/f207250e2f9d4602b28c25c8a83a34bc42811243",
-                "reference": "f207250e2f9d4602b28c25c8a83a34bc42811243",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/e076c42ed718929dbea96c0b354ebe96cccc2335",
+                "reference": "e076c42ed718929dbea96c0b354ebe96cccc2335",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.0",
+                "hhvm": "^4.30",
                 "hhvm/hsl": "^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.0.0",
-                "hhvm/hacktest": "^1.0",
+                "hhvm/hacktest": "^2.0",
                 "hhvm/hhast": "^4.0",
                 "hhvm/hhvm-autoload": "^2.0"
             },
@@ -275,7 +288,7 @@
                 "TypeAssert",
                 "hack"
             ],
-            "time": "2019-02-08T23:10:16+00:00"
+            "time": "2020-01-13T21:48:58+00:00"
         }
     ],
     "aliases": [],
@@ -284,8 +297,5 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": [],
-    "platform-overrides": {
-        "hhvm": "4.0.0"
-    }
+    "platform-dev": []
 }

--- a/src/RequestInterface.hh
+++ b/src/RequestInterface.hh
@@ -30,7 +30,7 @@
 
 namespace Facebook\Experimental\Http\Message;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 enum HTTPMethod: string {
   PUT     = 'PUT';

--- a/src/ResponseInterface.hh
+++ b/src/ResponseInterface.hh
@@ -30,7 +30,7 @@
 
 namespace Facebook\Experimental\Http\Message;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 /**
  * Representation of an outgoing, server-side response.

--- a/src/UploadedFileInterface.hh
+++ b/src/UploadedFileInterface.hh
@@ -29,7 +29,7 @@
  */
 
 namespace Facebook\Experimental\Http\Message;
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 enum UploadedFileError: int {
 	ERROR_EXCEEDS_MAX_INI_SIZE = 1;


### PR DESCRIPTION
I don't think there's a way to make this backwards compatible, so this changes the HHVM requirement from 3.29 (may have been inaccurate already?) to 4.41 (oldest version supported by hsl-experimental 4.50).

This would be a new release (v0.3), so people could still use v0.2 of the interfaces with older HHVMs, since the interfaces are unchanged.