### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
+          - "4.128"
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
         "hhvm/hhast": "^4.0"
     },
     "require": {
-        "hhvm/hsl-experimental": "^4.50"
+        "hhvm": "^4.128"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,15 @@
     "description": "Common interface for HTTP messages",
     "homepage": "https://github.com/facebookexperimental/hack-http-request-response-interfaces",
     "require-dev": {
-        "hhvm/hhast": "^4.0"
+        "hhvm/hhast": "^4.0",
+        "hhvm/hhvm-autoload": "^3"
     },
     "require": {
         "hhvm": "^4.128"
+    },
+    "config": {
+        "allow-plugins": {
+            "hhvm/hhvm-autoload": true
+        }
     }
 }

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -3,5 +3,6 @@
         "src"
     ],
     "devRoots": [],
-    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+    "useFactsIfAvailable": true
 }


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.